### PR TITLE
docs(readme): fix typo on css filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install react-super-responsive-table --save
 ## Usage
 
 1. `import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'`
-2. Copy or import `react-super-responsive-table/dist/superResponsiveTableStyles.css` into your project
+2. Copy or import `react-super-responsive-table/dist/SuperResponsiveTableStyles.css` into your project
 3. Write your html table with the imported components.
 
 ```jsx


### PR DESCRIPTION
## Description

Thanks for this lib 🎉

When installing it I've copied the CSS filename from outside the code block, and it has a lowercase `s`.

Simple fix :)

## Types of changes

- Documentation update
