### PR TITLE
feat: forward refs for table component

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -15,7 +15,7 @@ class Table extends React.Component {
 
   render() {
     const { headers } = this.state;
-    const { className } = this.props;
+    const { className, forwardedRef } = this.props;
     const classes = `${className || ''} responsiveTable`;
 
     return (
@@ -24,6 +24,7 @@ class Table extends React.Component {
           data-testid="table"
           {...allowed(this.props)}
           className={classes}
+          ref={forwardedRef}
         />
       </Provider>
     );
@@ -32,10 +33,21 @@ class Table extends React.Component {
 
 Table.propTypes = {
   className: T.string,
+  forwardedRef: T.oneOfType([
+    T.func,
+    T.shape({ current: T.instanceOf(global.Element) }),
+  ]),
 };
 
 Table.defaultProps = {
   className: undefined,
+  forwardedRef: undefined,
 };
 
-export default Table;
+const TableForwardRef = React.forwardRef((props, ref) => (
+  <Table {...props} forwardedRef={ref} />
+));
+
+TableForwardRef.displayName = Table.name;
+
+export default TableForwardRef;

--- a/src/utils/allowed.js
+++ b/src/utils/allowed.js
@@ -3,6 +3,7 @@ const omit = (obj, omitProps) =>
     .filter((key) => omitProps.indexOf(key) === -1)
     .reduce((returnObj, key) => ({ ...returnObj, [key]: obj[key] }), {});
 
-const allowed = (props) => omit(props, ['inHeader', 'columnKey', 'headers']);
+const allowed = (props) =>
+  omit(props, ['inHeader', 'columnKey', 'headers', 'forwardedRef']);
 
 export default allowed;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change allows you to forward a ref to the `<table>` DOM element, which is useful for doing further DOM manipulations after render. Example:

```jsx
const Component = () => {
  const tableRef = useRef(null);

  useEffect(() => {
    if (tableRef.current) {
      // ... do something with the <table> DOM element ...
    }
  });

  return (
    <Table ref={tableRef}>
      { /* table contents */ }
    </Table>
  );
};
```

## Types of changes

<!--- Leave the one fitting to your PR  -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- My code follows the code style of this project.
- If my change requires a change to the documentation I have updated the documentation accordingly.
