### PR TITLE
Fix Row Height Responsiveness

### DIFF
--- a/src/SuperResponsiveTableStyle.css
+++ b/src/SuperResponsiveTableStyle.css
@@ -37,8 +37,8 @@
   .responsiveTable td.pivoted {
     /* Behave like a "row" */
     border: none !important;
+    display: block;
     position: relative;
-    padding-left: calc(50% + 10px) !important;
     text-align: left !important;
     white-space: pre-wrap;
     overflow-wrap: break-word;
@@ -46,8 +46,7 @@
 
   .responsiveTable td .tdBefore {
     /* Now like a table header */
-    position: absolute;
-    display: block;
+    display: inline-flex;
 
     /* Top/left values mimic padding */
     left: 1rem;
@@ -56,5 +55,10 @@
     overflow-wrap: break-word;
     text-align: left !important;
     font-weight: 600;
+  }
+
+  .responsiveTable td .tdAfter {
+    display: inline-flex;
+    padding-left: 10px;
   }
 }

--- a/src/components/TdInner.js
+++ b/src/components/TdInner.js
@@ -15,7 +15,9 @@ function TdInner(props) {
       <div data-testid="td-before" className="tdBefore">
         {headers[columnKey]}
       </div>
-      {children ?? <div>&nbsp;</div>}
+      <div data-testid="td-after" className="tdAfter">
+        {children ?? <div>&nbsp;</div>}
+      </div>
     </td>
   );
 }


### PR DESCRIPTION
If the header contains more lines of text than than the data, the height of the row will accommodate it.

This fixes the following bug:
<img width="320" alt="image" src="https://user-images.githubusercontent.com/33408946/263071634-33111a59-8d05-482c-af0c-f3544698f3f3.png">

After:
<img width="320" alt="image" src="https://github.com/coston/react-super-responsive-table/assets/33408946/ef8e840e-5644-421b-a843-93be92e11b6a">