### PR TITLE
Change of name global object global to globalThis

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -35,7 +35,7 @@ Table.propTypes = {
   className: T.string,
   forwardedRef: T.oneOfType([
     T.func,
-    T.shape({ current: T.instanceOf(global.Element) }),
+    T.shape({ current: T.instanceOf(globalThis.Element) }),
   ]),
 };
 


### PR DESCRIPTION
<!--- Change of name global object global to globalThis -->

## Description

Change of name global object global to globalThis because the name "global" is deprecated.