### PR TITLE
Remove deprecated defaultProps

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -39,11 +39,6 @@ Table.propTypes = {
   ]),
 };
 
-Table.defaultProps = {
-  className: undefined,
-  forwardedRef: undefined,
-};
-
 const TableForwardRef = React.forwardRef((props, ref) => (
   <Table {...props} forwardedRef={ref} />
 ));

--- a/src/components/TdInner.js
+++ b/src/components/TdInner.js
@@ -28,12 +28,4 @@ TdInner.propTypes = {
   colSpan: T.oneOfType([T.number, T.string]),
 };
 
-TdInner.defaultProps = {
-  children: undefined,
-  headers: undefined,
-  columnKey: undefined,
-  className: undefined,
-  colSpan: undefined,
-};
-
 export default TdInner;

--- a/src/components/Thead.js
+++ b/src/components/Thead.js
@@ -17,8 +17,4 @@ Thead.propTypes = {
   children: T.node,
 };
 
-Thead.defaultProps = {
-  children: undefined,
-};
-
 export default Thead;

--- a/src/components/TrInner.js
+++ b/src/components/TrInner.js
@@ -42,10 +42,4 @@ TrInner.propTypes = {
   inHeader: T.bool,
 };
 
-TrInner.defaultProps = {
-  children: undefined,
-  headers: undefined,
-  inHeader: undefined,
-};
-
 export default TrInner;


### PR DESCRIPTION
Smaller-scope reattempt of https://github.com/coston/react-super-responsive-table/pull/534 that fixes the warning that latest versions of React give about using the now-deprecated `defaultProps`.

## Description

Unlike https://github.com/coston/react-super-responsive-table/pull/534 this PR does not do any refactoring of the class components into FCs etc.

*Note: since the default value of any missing prop is always `undefined`, the correct way to port these `defaultProps` is to simply remove them, i.e.:

```
class X extends React.Component {}
X.defaultProps = {
    className: undefined
}

// ... is the same as...

const X = ({ className = undefined }) {}

// ... is the same as ...

const X = ({ className }) {}

```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- ✅  My code follows the code style of this project.
- ✅ If my change requires a change to the documentation I have updated the documentation accordingly.
